### PR TITLE
UUID support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,6 @@ version = "0.10.4"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-IndexedTables = "6deec6e2-d858-57c5-ab9b-e6ca5bd20e43"
-JuliaDB = "a93385a2-3734-596a-9a66-3cfbb77141e6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.10.4"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 IndexedTables = "6deec6e2-d858-57c5-ab9b-e6ca5bd20e43"
+JuliaDB = "a93385a2-3734-596a-9a66-3cfbb77141e6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.10.3"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+IndexedTables = "6deec6e2-d858-57c5-ab9b-e6ca5bd20e43"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CQLdriver"
 uuid = "9d1c9671-1ee4-5573-9bdf-56d4f028cf50"
-version = "0.10.4"
+version = "0.11.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CQLdriver"
 uuid = "9d1c9671-1ee4-5573-9bdf-56d4f028cf50"
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/CQLdriver.jl
+++ b/src/CQLdriver.jl
@@ -1,7 +1,7 @@
 __precompile__(true)
 
 module CQLdriver
-using DataFrames, Dates, StructArrays, IndexedTables, JuliaDB
+using DataFrames, Dates, StructArrays
 
 export DataFrames, cqlinit, cqlclose, cqlwrite, cqlread, cqlexec, cql_uuid_gen_new, cql_uuid_gen_free, cql_uuid_gen_random
 

--- a/src/CQLdriver.jl
+++ b/src/CQLdriver.jl
@@ -283,6 +283,7 @@ Bind data to a column in a statement for use with batch inserts
 - `Void`:
 """
 cqlstatementbind(statement::Ptr{CassStatement}, pos::Int, data::Missing) = nothing # default to unset_value
+cqlstatementbind(statement::Ptr{CassStatement}, pos::Int, data::CassUuid) = cql_statement_bind_uuid(statement, pos, data)
 cqlstatementbind(statement::Ptr{CassStatement}, pos::Int, data::String) = cql_statement_bind_string(statement, pos, data)
 cqlstatementbind(statement::Ptr{CassStatement}, pos::Int, data::Bool) = cql_statement_bind_bool(statement, pos, data)
 cqlstatementbind(statement::Ptr{CassStatement}, pos::Int, data::Int8) = cql_statement_bind_int8(statement, pos, data)

--- a/src/CQLdriver.jl
+++ b/src/CQLdriver.jl
@@ -1,7 +1,7 @@
 __precompile__(true)
 
 module CQLdriver
-using DataFrames, Dates, StructArrays
+using DataFrames, Dates, StructArrays, IndexedTables, JuliaDB
 
 export DataFrames, cqlinit, cqlclose, cqlwrite, cqlread, cqlexec, cql_uuid_gen_new, cql_uuid_gen_free, cql_uuid_gen_random
 

--- a/src/CQLdriver.jl
+++ b/src/CQLdriver.jl
@@ -3,8 +3,7 @@ __precompile__(true)
 module CQLdriver
 using DataFrames, Dates, StructArrays, IndexedTables, JuliaDB
 
-export DataFrames, cqlinit, cqlclose, cqlwrite, cqlread, cqlexec
-export cql_uuid_gen_new, cql_uuid_gen_free, cql_uuid_gen_random
+export DataFrames, cqlinit, cqlclose, cqlwrite, cqlread, cqlexec, cql_uuid_gen_new, cql_uuid_gen_free, cql_uuid_gen_random
 
 include("cqlwrapper.jl")
 const CQL_OK = 0x0000

--- a/src/CQLdriver.jl
+++ b/src/CQLdriver.jl
@@ -2,7 +2,9 @@ __precompile__(true)
 
 module CQLdriver
 using DataFrames, Dates, StructArrays, IndexedTables, JuliaDB
+
 export DataFrames, cqlinit, cqlclose, cqlwrite, cqlread, cqlexec
+export cql_uuid_gen_new, cql_uuid_gen_free, cql_uuid_gen_random
 
 include("cqlwrapper.jl")
 const CQL_OK = 0x0000

--- a/src/CQLdriver.jl
+++ b/src/CQLdriver.jl
@@ -169,6 +169,12 @@ retrieve value using the correct type
 # Return
 - `out`: the return value, can by of any type
 """
+function cqlgetvalue(val::Ptr{CassValue}, T::Type{Union{CassUuid, Missing}}, strlen::Int)
+	num = Ref{CassUuid}(NULL_UUID)
+	err = cql_value_get_uuid(val, num)
+	return ifelse(err == CQL_OK, num[], missing)
+end
+
 function cqlgetvalue(val::Ptr{CassValue}, T::Type{Union{Int64, Missing}}, strlen::Int)
     num = Ref{Clonglong}(0)
     err = cql_value_get_int64(val, num)

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -23,7 +23,7 @@ end
 mutable struct CassUuid
     time_and_version::UInt64
     clock_seq_and_node::UInt64
-    CassUuid() = CassUuid(ZERO_UInt64,ZERO_UInt64)
+    CassUuid() = new(ZERO_UInt64,ZERO_UInt64)
 end
 
 function cql_cluster_set_concurrency(cluster::Ptr{CassCluster}, nthreads::Int64)

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -1,7 +1,9 @@
 using Base.Libc
 
 const SIZE_INT_128 = 16
-const ZERO_UINT_64 = UInt64(0)
+
+const CassUuid = UInt128
+const NULL_UUID = UInt128(0)
 
 macro genstruct(x)
     return :(mutable struct $x end)
@@ -19,12 +21,6 @@ end
 @genstruct CassPrepared
 @genstruct CassBatch
 @genstruct CassUuidGen
-
-mutable struct CassUuid
-    time_and_version::UInt64
-    clock_seq_and_node::UInt64
-    CassUuid() = new(ZERO_UINT_64,ZERO_UINT_64)
-end
 
 function cql_cluster_set_concurrency(cluster::Ptr{CassCluster}, nthreads::Int64)
     val = ccall(
@@ -82,8 +78,6 @@ function cql_cluster_set_queue_size(cluster::Ptr{CassCluster}, siz::Int64)
     val = val1 | val2
     return val::UInt16
 end
-
-
 
 function cql_future_error_code(future::Ptr{CassFuture})
     val = ccall(
@@ -489,11 +483,11 @@ function cql_uuid_gen_free(uuid_gen::Ptr{CassUuidGen})
 end
 
 function cql_uuid_gen_random(uuid_gen::Ptr{CassUuidGen})
-    uuid = Ref{CassUuid}(CassUuid())
+    uuid = Ref{CassUuid}(NULL_UUID)
     ccall(
         (:cass_uuid_gen_random, "libcassandra.so.2"),
         Nothing,
-        (Ptr{CassUuidGen}, Ptr{CassUuid}),
+        (Ptr{CassUuidGen}, Ref{CassUuid}),
         uuid_gen, uuid)
     return uuid.x
 end

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -1,7 +1,5 @@
 using Base.Libc
 
-const SIZE_INT_128 = 16
-
 const CassUuid = UInt128
 const NULL_UUID = UInt128(0)
 

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -17,8 +17,13 @@ end
 @genstruct CassValue
 @genstruct CassPrepared
 @genstruct CassBatch
-@genstruct CassUuid
 @genstruct CassUuidGen
+
+mutable struct CassUuid
+    time_and_version::UInt64
+    clock_seq_and_node::UInt64
+    CassUuid() = CassUuid(0x0,0x0)
+end
 
 function cql_cluster_set_concurrency(cluster::Ptr{CassCluster}, nthreads::Int64)
     val = ccall(
@@ -483,13 +488,13 @@ function cql_uuid_gen_free(uuid_gen::Ptr{CassUuidGen})
 end
 
 function cql_uuid_gen_random(uuid_gen::Ptr{CassUuidGen})
-    uuid::Ptr{CassUui}
+    uuid = Ref{CassUuid}(CassUuid())
     ccall(
         (:cass_uuid_gen_random, "libcassandra.so.2"),
         Nothing,
         (Ptr{CassUuidGen}, Ptr{CassUuid}),
         uuid_gen, uuid)
-    return uuid::Ptr{CassUui}
+    return uuid.x
 end
 
 function cql_statement_bind_uuid(statement::Ptr{CassStatement}, pos::Int, data::CassUuid)

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -1,6 +1,7 @@
 using Base.Libc
 
 const SIZE_INT_128 = 16
+const ZERO_UInt64 = UInt64(0)
 
 macro genstruct(x)
     return :(mutable struct $x end)
@@ -22,7 +23,7 @@ end
 mutable struct CassUuid
     time_and_version::UInt64
     clock_seq_and_node::UInt64
-    CassUuid() = CassUuid(0x0,0x0)
+    CassUuid() = CassUuid(ZERO_UInt64,ZERO_UInt64)
 end
 
 function cql_cluster_set_concurrency(cluster::Ptr{CassCluster}, nthreads::Int64)

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -478,7 +478,7 @@ function cql_uuid_gen_free(uuid_gen::CassUuidGen)
     ccall(
         (:cass_uuid_gen_free, "libcassandra.so.2"),
         Nothing,
-        (Ptr{CassUuidGen},)
+        (Ptr{CassUuidGen},),
         uuid_gen)
 end
 
@@ -496,7 +496,7 @@ function cql_statement_bind_uuid(statement::Ptr{CassStatement}, pos::Int, data::
     ccall(
         (:cass_statement_bind_uuid, "libcassandra.so.2"),
         Nothing,
-        (Ptr{CasStatement}, Cint, Ptr{CassUuid}),
+        (Ptr{CassStatement}, Cint, Ptr{CassUuid}),
         statement, pos, data)
 end
 

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -474,7 +474,7 @@ function cql_uuid_gen_new()
     return uuid_gen::Ptr{CassUuidGen}
 end
 
-function cql_uuid_gen_free(uuid_gen::CassUuidGen)
+function cql_uuid_gen_free(uuid_gen::Ptr{CassUuidGen})
     ccall(
         (:cass_uuid_gen_free, "libcassandra.so.2"),
         Nothing,
@@ -482,7 +482,7 @@ function cql_uuid_gen_free(uuid_gen::CassUuidGen)
         uuid_gen)
 end
 
-function cql_uuid_gen_random(uuid_gen::CassUuidGen)
+function cql_uuid_gen_random(uuid_gen::Ptr{CassUuidGen})
     uuid = malloc(SIZE_INT_128)
     ccall(
         (:cass_uuid_gen_random, "libcassandra.so.2"),

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -502,7 +502,7 @@ function cql_statement_bind_uuid(statement::Ptr{CassStatement}, pos::Int, data::
     ccall(
         (:cass_statement_bind_uuid, "libcassandra.so.2"),
         Nothing,
-        (Ptr{CassStatement}, Cint, Ptr{CassUuid}),
+        (Ptr{CassStatement}, Cint, CassUuid),
         statement, pos, data)
 end
 

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -483,13 +483,13 @@ function cql_uuid_gen_free(uuid_gen::Ptr{CassUuidGen})
 end
 
 function cql_uuid_gen_random(uuid_gen::Ptr{CassUuidGen})
-    uuid = malloc(SIZE_INT_128)
+    uuid::Ptr{CassUui}
     ccall(
         (:cass_uuid_gen_random, "libcassandra.so.2"),
         Nothing,
         (Ptr{CassUuidGen}, Ptr{CassUuid}),
         uuid_gen, uuid)
-    return dereference(CassUuid,uuid)
+    return uuid::Ptr{CassUui}
 end
 
 function cql_statement_bind_uuid(statement::Ptr{CassStatement}, pos::Int, data::CassUuid)

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -214,6 +214,15 @@ function cql_result_column_type(result::Ptr{CassResult}, idx::Int64)
     return val::UInt16
 end
 
+function cql_value_get_uuid(val::Ptr{CassValue}, out::Ref{CassUuid})
+    err = ccall(
+            (:cass_value_get_uuid, "libcassandra.so.2"),
+            Cushort,
+            (Ptr{CassValue}, Ref{CassUuid}),
+            val, out)
+    return err::UInt16
+end
+
 function cql_value_get_int8(val::Ptr{CassValue}, out::Ref{Cshort})
     err = ccall(
             (:cass_value_get_int8, "libcassandra.so.2"),

--- a/src/cqlwrapper.jl
+++ b/src/cqlwrapper.jl
@@ -1,7 +1,7 @@
 using Base.Libc
 
 const SIZE_INT_128 = 16
-const ZERO_UInt64 = UInt64(0)
+const ZERO_UINT_64 = UInt64(0)
 
 macro genstruct(x)
     return :(mutable struct $x end)
@@ -23,7 +23,7 @@ end
 mutable struct CassUuid
     time_and_version::UInt64
     clock_seq_and_node::UInt64
-    CassUuid() = new(ZERO_UInt64,ZERO_UInt64)
+    CassUuid() = new(ZERO_UINT_64,ZERO_UINT_64)
 end
 
 function cql_cluster_set_concurrency(cluster::Ptr{CassCluster}, nthreads::Int64)


### PR DESCRIPTION
* Added the `CassUuidGen' struct type
* Added the `CassUuid` type as a `UInt128` type alias
* Implemented wrapper `cql_uuid_gen_new` to wrap `cass_uuid_gen_new` for creating a new `CassUuidGen'
* Implemented wrapper `cql_uuid_gen_free` to wrap `cass_uuid_gen_free`  for freeing a `CassUuidGen'
* Implemented wrapper `cql_uuid_gen_random` to wrap `cass_uuid_gen_random` for generating a `CassUuid` using a `CassUuidGen'
* Implemented wrapper `cql_value_get_uuid` to wrap `cass_value_get_uuid` for getting a `CassUuid` from a `CassValue`
* Implemented `cqlgetvalue` for the `CassUuid` type, using `cql_value_get_uuid`
* Implemented wrapper `cql_statement_bind_uuid` to wrap `cass_statement_bind_uuid` to bind a `CassUuid` to a `CassStatement`
* Implemented `cqlstatementbind` for the `CassUuid` type using `cql_statement_bind_uuid`
* Upped minor version (addition of new feature)