### PR TITLE
Make UUIDs match even in string representation between Cassandra and Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ IndexedTables = "6deec6e2-d858-57c5-ab9b-e6ca5bd20e43"
 JuliaDB = "a93385a2-3734-596a-9a66-3cfbb77141e6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 DataFrames = "0.18, 0.19, 0.20, 0.21"


### PR DESCRIPTION
I noticed that with the current version of UUID -> `UInt128` typing, the actual byte ordering differs between Cassandra and Julia such that you don't get the same UUID in Cassandra as you do in Julia (via the `UUIDs` package in the standard library).

For example, if you have Julia values like so:

```julia
df = DataFrame(:email => ["example@example.com"], :id => [UInt128(UUID("083775e3-d9cb-4bd3-9dd3-e249b4a7a502"))])
cqlwrite(session, "users.user_id_by_email", df)
```
you end up with a different UUID in Cassandra, like so:

```cqlsh
user@cqlsh> select * from users.user_id_by_email;

 email               | id
---------------------+--------------------------------------
 example@example.com | b4a7a502-e249-9dd3-0837-75e3d9cb4bd3
```

Now, the byte reordering is consistent, so if you roundtrip back to Julia you'll get the same UUID as you had before, but if you are using any other client besides this library (e.g. using `cqlsh` directly), you'll hit issues.

I'm pretty new to Julia, so my fix here is not the most beautiful code, but I think some version of this correction should be brought in!

NOTE: I am currently running Scylla instead of Apache Cassandra, so even though Scylla implements the Cassandra API, there's a slight chance the issue I'm seeing is specific to Scylla. If will try to verify against a running Apache Cassandra instance as well.