### PR TITLE
IndexedTable not DIndexedTable (?)

### DIFF
--- a/src/CQLdriver.jl
+++ b/src/CQLdriver.jl
@@ -712,7 +712,7 @@ function cqlwrite(s::Ptr{CassSession}, cass_table::String, data::Union{DataFrame
     return err::UInt16
 end
 
-function cqlwrite(s::Ptr{CassSession}, cass_table::String, data::JuliaDB.DIndexedTable; paritionsize::Int=100000, batchsize::Int=500, retries::Int=5, counter::Bool=false)
+function cqlwrite(s::Ptr{CassSession}, cass_table::String, data::JuliaDB.IndexedTable; paritionsize::Int=100000, batchsize::Int=500, retries::Int=5, counter::Bool=false)
     errs = Vector{UInt16}()
     for tbl = Iterators.partition(data, paritionsize)
         push!(errs, cqlwrite(s, cass_table, tbl; batchsize=batchsize, retries=retries, counter=counter))


### PR DESCRIPTION
Is this a typo? I just got a precompile error when writing a unit test.

```
ERROR: LoadError: UndefVarError: DIndexedTable not defined
Stacktrace:
 [1] getproperty(x::Module, f::Symbol)
   @ Base ./Base.jl:26
 [2] top-level scope
   @ ~/.julia/dev/CQLdriver/src/CQLdriver.jl:716
 [3] include
   @ ./Base.jl:386 [inlined]
 [4] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::String)
   @ Base ./loading.jl:1213
 [5] top-level scope
   @ none:1
 [6] eval
   @ ./boot.jl:360 [inlined]
 [7] eval(x::Expr)
   @ Base.MainInclude ./client.jl:446
 [8] top-level scope
   @ none:1
in expression starting at /home/luke/.julia/dev/CQLdriver/src/CQLdriver.jl:3
ERROR: LoadError: Failed to precompile CQLdriver [9d1c9671-1ee4-5573-9bdf-56d4f028cf50] to /home/luke/.julia/compiled/v1.6/CQLdriver/jl_6vXUGm.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::Base.TTY, internal_stdout::Base.TTY)
   @ Base ./loading.jl:1360
 [3] compilecache(pkg::Base.PkgId, path::String)
   @ Base ./loading.jl:1306
 [4] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:1021
 [5] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:914
 [6] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:901
```